### PR TITLE
fix incorrect cropping transformation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ not appear in your final article.
 
 Available operations for transformations are:
 
-* `crop <top> <left> <right> <bottom>`:
+* `crop <left> <top> <right> <bottom>`:
 
     Crop the image to the box (`<left>`, `<top>`)-(`<right>`, `<bottom>`). Values
     can be absolute (a number) or relative to the size of the image (a


### PR DESCRIPTION
I was getting a vague error of `'NoneType' object is not subscriptable` and it turned out it was because my thumbnail cropping settings were out of the expected range.

It appears the cropping values are expecting the format `x1, y1, x2, y2` but it was listed `y1, x1, x2, y2`.